### PR TITLE
Added mission info scaleform

### DIFF
--- a/critScaleforms/client/cl_examples.lua
+++ b/critScaleforms/client/cl_examples.lua
@@ -28,7 +28,7 @@ RegisterCommand('me', function() --midsize banner. Same as big banner, but midsi
     TriggerEvent("cS.MidsizeBanner", "~y~Test Scaleform~s~.", "You ~g~can ~r~use ~y~colors ~b~here ~s~too.", 5, true)
 end)
 
-RegisterCommand('rp', function() --Results pannel. _slots argument needs to be a table. slots[i].state can be 0 or 2 for "not selected" and 1 or 3 for "selected".
+RegisterCommand('rp', function() --Results panel. _slots argument needs to be a table. slots[i].state can be 0 or 2 for "not selected" and 1 or 3 for "selected".
     local slots = {
         {name = "test1", state = 0},
         {name = "test2", state = 1},
@@ -37,6 +37,21 @@ RegisterCommand('rp', function() --Results pannel. _slots argument needs to be a
     }
     --TriggerEvent("cS.resultsPanel", _title, _subtitle, _slotsTable, _waitTimeSeconds, _playSound)
     TriggerEvent("cS.resultsPanel", "~y~Test Scaleform~s~.", "You ~g~can ~r~use ~y~colors ~b~here ~s~too.", slots, 5, true)
+end)
+
+RegisterCommand('mi', function() --Mission info panel
+    local data = {
+        name = "Mission name",
+        type = "Mission type",
+        percentage = "15",
+        rockstarVerified = true,
+        playersRequired = "3",
+        rp = 0,
+        cash = 0,
+        time = ""
+    }
+    --TriggerEvent("cS.missionInfo", _data, _x, _y, _width, _waitTime, _playSound)
+    TriggerEvent("cS.missionInfo", data, 0.5, 0.5, 0.5, 5, true)
 end)
 
 RegisterCommand('heist', function()

--- a/critScaleforms/client/cl_main.lua
+++ b/critScaleforms/client/cl_main.lua
@@ -1,6 +1,7 @@
 showBanner = false
 showMQ = false
 showRP = false
+showMI = false
 showST = false
 showPW = false
 showCD = false
@@ -41,6 +42,18 @@ AddEventHandler("cS.resultsPanel", function(_title, _subtitle, _slots, _waitTime
     Citizen.CreateThread(function()
         Citizen.Wait(tonumber(_waitTime) * 1000)
         showRP = false
+    end)
+end)
+
+AddEventHandler("cS.missionInfo", function(_data, _x, _y, _width, _waitTime, _playSound)
+    showMI = true
+    if _playSound ~= nil and _playSound == true then
+        PlaySoundFrontend(-1, "CHECKPOINT_PERFECT", "HUD_MINI_GAME_SOUNDSET", 1)
+    end
+    ShowMissionInfoPanel(_data, _x, _y, _width)
+    Citizen.CreateThread(function()
+        Citizen.Wait(tonumber(_waitTime) * 1000)
+        showMI = false
     end)
 end)
 

--- a/critScaleforms/client/cl_scaleform_functions.lua
+++ b/critScaleforms/client/cl_scaleform_functions.lua
@@ -111,6 +111,40 @@ function ShowResultsPanel(_title, _subtitle, _slots)
     end)
 end
 
+function ShowMissionInfoPanel(_data, _x, _y, _width)
+    Citizen.CreateThread(function()
+        function drawMissionInfo(data)
+            local scaleform = RequestScaleformMovie("MP_MISSION_NAME_FREEMODE")
+            while not HasScaleformMovieLoaded(scaleform) do
+                Citizen.Wait(0)
+            end
+            BeginScaleformMovieMethod(scaleform, "SET_MISSION_INFO")
+            PushScaleformMovieMethodParameterString(data.name)
+            PushScaleformMovieMethodParameterString(data.type)
+            PushScaleformMovieMethodParameterString("")
+            PushScaleformMovieMethodParameterString(data.percentage)
+            PushScaleformMovieMethodParameterString("")
+            PushScaleformMovieMethodParameterBool(data.rockstarVerified)
+            PushScaleformMovieMethodParameterString(data.playersRequired)
+            PushScaleformMovieMethodParameterInt(data.rp)
+            PushScaleformMovieMethodParameterInt(data.cash)
+            PushScaleformMovieMethodParameterString(data.time)
+            EndScaleformMovieMethod()
+
+            return scaleform
+        end
+        local scale = drawMissionInfo(_data)
+        while showMI do
+            Citizen.Wait(1)
+            local x = 0.5
+            local y = 0.5
+            local width = 0.5
+            local height = width / 0.65
+            DrawScaleformMovie(scale, x, y, width, height, 255, 255, 255, 255, 0)
+        end
+    end)
+end
+
 function showMissionQuit(_title, _subtitle, _duration)
     Citizen.CreateThread(function()
         function drawScale(string1, string2, duration)


### PR DESCRIPTION
Added the mission info scaleform:

![image](https://user-images.githubusercontent.com/16289288/126707233-1a0127cf-03e9-47fc-bc72-729cb0c71c15.png)

```
    local data = {
        name = "Mission name",
        type = "Mission type",
        percentage = "15",
        rockstarVerified = true,
        playersRequired = "3",
        rp = 0,
        cash = 0,
        time = ""
    }
    --TriggerEvent("cS.missionInfo", _data, _x, _y, _width, _waitTime, _playSound)
    TriggerEvent("cS.missionInfo", data, 0.5, 0.5, 0.5, 5, true)
```

_x defines the x location on the screen
_y defines the y location on the screen
_width defines the with of the scaleform